### PR TITLE
Support exporting non-fullchain cert file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jobs:
           arguments: --dns dns_cf --challenge-alias example.com
           arguments-file: ''
 
+          output-cert: output/cert.pem
           output-fullchain: output/fullchain.pem
           output-key: output/key.pem
           output-pfx: output/certificate.pfx

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: The file containing arguments to pass to acme.sh (will be prepended to all `-d domain.name` items). The first argument `--issue` should be omitted. For example `--dns dns_cf --challenge-alias example.com`. Overrides `arguments` field.
     required: false
     default: ''
+  output-cert:
+    description: The target path for the issued certificate's cert PEM file. Omit if you don't need.
+    required: false
+    default: ''
   output-fullchain:
     description: The target path for the issued certificate's fullchain PEM file. Omit if you don't need.
     required: false
@@ -142,9 +146,11 @@ runs:
     - name: Copy certificate to output paths
       run: |
         ACME_SH_TEMP_DIR="$(mktemp -d)"
+        ACME_SH_TEMP_FILE_CERT="$ACME_SH_TEMP_DIR/cert.pem"
         ACME_SH_TEMP_FILE_FULLCHAIN="$ACME_SH_TEMP_DIR/fullchain.pem"
         ACME_SH_TEMP_FILE_KEY="$ACME_SH_TEMP_DIR/key.pem"
-        ~/.acme.sh/acme.sh --install-cert -d "$ACME_SH_FIRST_DOMAIN" --fullchain-file "$ACME_SH_TEMP_FILE_FULLCHAIN" --key-file "$ACME_SH_TEMP_FILE_KEY"
+        ~/.acme.sh/acme.sh --install-cert -d "$ACME_SH_FIRST_DOMAIN" --cert-file "$ACME_SH_TEMP_FILE_CERT" --fullchain-file "$ACME_SH_TEMP_FILE_FULLCHAIN" --key-file "$ACME_SH_TEMP_FILE_KEY"
+        [[ -z "$ACME_SH_OUTPUT_CERT" ]] || (mkdir -p "$(dirname "$ACME_SH_OUTPUT_CERT")" && cp "$ACME_SH_TEMP_FILE_CERT" "$ACME_SH_OUTPUT_CERT")
         [[ -z "$ACME_SH_OUTPUT_FULLCHAIN" ]] || (mkdir -p "$(dirname "$ACME_SH_OUTPUT_FULLCHAIN")" && cp "$ACME_SH_TEMP_FILE_FULLCHAIN" "$ACME_SH_OUTPUT_FULLCHAIN")
         [[ -z "$ACME_SH_OUTPUT_KEY" ]] || (mkdir -p "$(dirname "$ACME_SH_OUTPUT_KEY")" && cp "$ACME_SH_TEMP_FILE_KEY" "$ACME_SH_OUTPUT_KEY")
         [[ -z "$ACME_SH_OUTPUT_PFX" ]] || (mkdir -p "$(dirname "$ACME_SH_OUTPUT_PFX")" && (
@@ -157,6 +163,7 @@ runs:
         rm -rf "$ACME_SH_TEMP_DIR"
       shell: bash
       env:
+        ACME_SH_OUTPUT_CERT: ${{ inputs.output-cert }}
         ACME_SH_OUTPUT_FULLCHAIN: ${{ inputs.output-fullchain }}
         ACME_SH_OUTPUT_KEY: ${{ inputs.output-key }}
         ACME_SH_OUTPUT_PFX: ${{ inputs.output-pfx }}


### PR DESCRIPTION
Support the option to export the cert file as a standalone item, even if its content is already included in the fullchain file.